### PR TITLE
Slashes flipped for UNIX compatibility

### DIFF
--- a/SCION_plot_fluxes.m
+++ b/SCION_plot_fluxes.m
@@ -67,8 +67,8 @@ pc6 = [82 56 100]./255 ;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%% load geochem data
-load('data\geochem_data_2020.mat')
-load('data\Scotese_GAT_2021.mat')
+load('data/geochem_data_2020.mat')
+load('data/Scotese_GAT_2021.mat')
 
 %%%%%%% make figure
 figure('Color',[1 0.98 0.95])


### PR DESCRIPTION
Suggesting flipping slashes in filepaths on lines 70 and 71 of SCION_plot_fluxes.m to ensure UNIX compatibility (found to be necessary to run on MacOS in my case).